### PR TITLE
Set threshold for Clair CVE scanning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
   - make test
   - docker images
-  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="Medium" --ip "$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')" $IMAGE_NAME:latest
+  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')" $IMAGE_NAME:latest
 
 before_deploy:
   - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"


### PR DESCRIPTION
#34 Per agreement with the Pega security team, the default build-failure threshold for the image scanner in this OSS project should be High, not Medium.