### PR TITLE
Fix clair-scanner network problem in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ install:
 script:
   - make test
   - docker images
-  - ifconfig
-  - hostname -i
   - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')" $IMAGE_NAME:latest
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - chmod +x clair-scanner
   - sudo mv clair-scanner /usr/local/bin
   - docker run -d --name db arminc/clair-db
-  - docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:latest
+  - docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.6
   - curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
   
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ install:
 script:
   - make test
   - docker images
-  - scannerip = $(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+  - ifconfig
+  - scannerip = $(hostname -i)
   - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$scannerip" $IMAGE_NAME:latest
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ script:
   - make test
   - docker images
   - ifconfig
-  - scannerip = $(hostname -i)
-  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$scannerip" $IMAGE_NAME:latest
+  - hostname -i
+  - $scannerip = $(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "127.0.0.1" $IMAGE_NAME:latest
 
 before_deploy:
   - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ install:
 script:
   - make test
   - docker images
-  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')" $IMAGE_NAME:latest
+  - scannerip = $(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$scannerip" $IMAGE_NAME:latest
 
 before_deploy:
   - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
   - docker images
   - ifconfig
   - hostname -i
-  - $scannerip = $(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
-  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "127.0.0.1" $IMAGE_NAME:latest
+  - $scannerip = $(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "127.0.1.1" $IMAGE_NAME:latest
 
 before_deploy:
   - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ script:
   - docker images
   - ifconfig
   - hostname -i
-  - $scannerip = $(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
-  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "127.0.1.1" $IMAGE_NAME:latest
+  - clair-scanner -w tests/cve-scan-whitelist.yaml -c "http://127.0.0.1:6060" --threshold="High" --ip "$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')" $IMAGE_NAME:latest
 
 before_deploy:
   - docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"


### PR DESCRIPTION
Travis-CI changed their docker networking so that clair scanner now needs to connect to the DB at an IP from the docker0 device rather than eth0.