### PR TITLE
Adding support to mount prlog4j2 file

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -29,6 +29,7 @@ mkdir -p $config_root
 secret_root="${pega_root}/secrets"
 mkdir -p $secret_root
 
+prlog4j2="${config_root}/prlog4j2.xml"
 context_xml="${config_root}/context.xml"
 tomcatusers_xml="${config_root}/tomcat-users.xml"
 
@@ -125,6 +126,16 @@ else
 fi
 
 /bin/dockerize -template ${CATALINA_HOME}/conf/Catalina/localhost/prweb.xml:${CATALINA_HOME}/conf/Catalina/localhost/prweb.xml
+
+#
+# Copying mounted prlog4j2 file to webapps/prweb/WEB-INF/classes
+#
+if [ -e "$prlog4j2" ]; then
+  echo "Loading prlog4j2 from ${prlog4j2}...";
+  cp "$prlog4j2" ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/
+else
+  echo "No prlog4j2 was specified in ${prlog4j2}.  Using defaults."
+fi
 
 #
 # Write config files from templates using dockerize ...

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -30,6 +30,7 @@ secret_root="${pega_root}/secrets"
 mkdir -p $secret_root
 
 prlog4j2="${config_root}/prlog4j2.xml"
+prconfig="${config_root}/prconfig.xml"
 context_xml="${config_root}/context.xml"
 tomcatusers_xml="${config_root}/tomcat-users.xml"
 
@@ -135,6 +136,16 @@ if [ -e "$prlog4j2" ]; then
   cp "$prlog4j2" ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/
 else
   echo "No prlog4j2 was specified in ${prlog4j2}.  Using defaults."
+fi
+
+#
+# Copying mounted prconfig file to webapps/prweb/WEB-INF/classes
+#
+if [ -e "$prconfig" ]; then
+  echo "Loading prconfig from ${prconfig}...";
+  cp "$prconfig" ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/
+else
+  echo "No prconfig was specified in ${prconfig}.  Using defaults."
 fi
 
 #


### PR DESCRIPTION
When the user mounts prlog4j2 file in /opt/pega/config folder, the Pega process uses the mounted file.