### PR TITLE
update setting names to dbcp 2 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ ENV JDBC_URL='' \
 ENV JDBC_DRIVER_URI=''
 
 # Provide variables for the JDBC connection string
-ENV JDBC_MIN_ACTIVE=50 \
-    JDBC_MAX_ACTIVE=250 \
+ENV JDBC_MAX_ACTIVE=250 \
     JDBC_MIN_IDLE=10 \
     JDBC_MAX_IDLE=50 \
     JDBC_MAX_WAIT=30000 \

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -9,8 +9,6 @@ metadataTest:
      value: /usr/local/tomcat
    - key: PATH
      value: /usr/local/tomcat/bin:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-   - key: JDBC_MIN_ACTIVE
-     value: 50
    - key: JDBC_MAX_ACTIVE
      value: 250
    - key: JDBC_MIN_IDLE

--- a/tests/test-artifacts/templates/context.xml.tmpl
+++ b/tests/test-artifacts/templates/context.xml.tmpl
@@ -13,7 +13,6 @@
 		url="{{ .Env.JDBC_URL }}"
 		username="{{ .Env.SECRET_DB_USERNAME }}"
 		password="{{ .Env.SECRET_DB_PASSWORD }}"
-		minActive="{{ .Env.JDBC_MIN_ACTIVE }}"
 		maxActive="{{ .Env.JDBC_MAX_ACTIVE }}"
 		minIdle="{{ .Env.JDBC_MIN_IDLE }}"
 		maxIdle="{{ .Env.JDBC_MAX_IDLE }}"

--- a/tests/test-artifacts/templates/expected_context.xml
+++ b/tests/test-artifacts/templates/expected_context.xml
@@ -13,11 +13,10 @@
 		url="jdbc:postgresql://localhost:5432/pegadb"
 		username="postgres"
 		password="postgres"
-		minActive="50"
-		maxActive="250"
+		maxTotal="250"
 		minIdle="10"
 		maxIdle="50"
-		maxWait="30000"
+		maxWaitMillis="30000"
         initialSize="50"
         connectionProperties="socketTimeout=90"
 	/>

--- a/tomcat-conf/context.xml.tmpl
+++ b/tomcat-conf/context.xml.tmpl
@@ -13,11 +13,10 @@
 		url="{{ .Env.JDBC_URL }}"
 		username="{{ .Env.SECRET_DB_USERNAME }}"
 		password="{{ .Env.SECRET_DB_PASSWORD }}"
-		minActive="{{ .Env.JDBC_MIN_ACTIVE }}"
-		maxActive="{{ .Env.JDBC_MAX_ACTIVE }}"
+		maxTotal="{{ .Env.JDBC_MAX_ACTIVE }}"
 		minIdle="{{ .Env.JDBC_MIN_IDLE }}"
 		maxIdle="{{ .Env.JDBC_MAX_IDLE }}"
-		maxWait="{{ .Env.JDBC_MAX_WAIT }}"
+		maxWaitMillis="{{ .Env.JDBC_MAX_WAIT }}"
         initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
         connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
 	/>


### PR DESCRIPTION
Tomcat 8 updated dbcp to 2.0, which changed a few of the setting names.  Since this image uses Tomcat 9 now, we need to use the updated versions.