### PR TITLE
Pass node tier to Pega 

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -9,10 +9,12 @@ JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true"
 # Append security overwrites
 #
 JAVA_OPTS="${JAVA_OPTS} -Djava.security.properties=/usr/local/tomcat/conf/java.security.overwrite"
+
 #
 # Pass Node tier to Pega
 #
 JAVA_OPTS="${JAVA_OPTS} -DNodeTier=${NODE_TIER}"
+
 #
 # Setup Heapdump path
 #

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -10,6 +10,10 @@ JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true"
 #
 JAVA_OPTS="${JAVA_OPTS} -Djava.security.properties=/usr/local/tomcat/conf/java.security.overwrite"
 #
+# Pass Node tier to Pega
+#
+JAVA_OPTS="${JAVA_OPTS} -DNodeTier=${NODE_TIER}"
+#
 # Setup Heapdump path
 #
 JAVA_OPTS="${JAVA_OPTS} -XX:HeapDumpPath=${HEAP_DUMP_PATH}"


### PR DESCRIPTION
Pass node tier from Kubernetes into Pega so that settings information can be viewed by tiers.