### PR TITLE
Pass Kubernetes admin studio functional variable

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -37,7 +37,7 @@ CATALINA_OPTS="${CATALINA_OPTS} -DmaxThreads=${MAX_THREADS}"
 # Node settings
 CATALINA_OPTS="${CATALINA_OPTS} -Didentification.nodeid=${HOSTNAME}"
 CATALINA_OPTS="${CATALINA_OPTS} -DNodeType=${NODE_TYPE}"
-CATALINA_OPTS="${CATALINA_OPTS} -DNodeSettings=\"${NODE_SETTINGS}\""
+CATALINA_OPTS="${CATALINA_OPTS} -DNodeSettings=\"Pega-IntegrationEngine/EnableRequestorPools=false;${NODE_SETTINGS}\""
 
 # Index settings
 #  When left blank, disable indexing.

--- a/tomcat-conf/Catalina/localhost/prweb.xml
+++ b/tomcat-conf/Catalina/localhost/prweb.xml
@@ -21,5 +21,6 @@
   <Environment name="prconfig/session/ha/quiesce/strategy/shutdownquiesce" value="true" type="java.lang.String"/>
   <Environment name="prconfig/session/ha/enabled" value="true" type="java.lang.String"/>
   <Environment name="prconfig/dsm/services/stream/pyBaseLogPath" value="/opt/pega/kafkadata" type="java.lang.String" />
-
+  <Environment name="prconfig/cloud/isNodeAgnosticAdminStudio" value="true" type="java.lang.String"/>
+  
 </Context>


### PR DESCRIPTION
Introducing the cloud/isNodeAgnosticAdminStudio variable to remove node specific functionality from Admin studio for Kubernetes environments. 
This variable has been created as functionality specific variable instead of a generic variable like isKubernetes. Also this variable is being added to the docker image instead of helm charts as advised by System Management.