### PR TITLE
ISSUE-67 Modified JDBC connection props to fix MSSQL read timeout connection exception

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,11 @@ ENV JDBC_URL='' \
 ENV JDBC_DRIVER_URI=''
 
 # Provide variables for the JDBC connection string
-ENV JDBC_MAX_ACTIVE=250 \
-    JDBC_MIN_IDLE=10 \
-    JDBC_MAX_IDLE=50 \
+ENV JDBC_MAX_ACTIVE=75 \
+    JDBC_MIN_IDLE=3 \
+    JDBC_MAX_IDLE=25 \
     JDBC_MAX_WAIT=30000 \
-    JDBC_INITIAL_SIZE=50 \
-    JDBC_CONNECTION_PROPERTIES="socketTimeout=90"
+    JDBC_INITIAL_SIZE=10 
 
 # Provide variables for the name of the rules, data, and customerdata schemas
 ENV RULES_SCHEMA=rules \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ ENV JDBC_MAX_ACTIVE=75 \
     JDBC_MIN_IDLE=3 \
     JDBC_MAX_IDLE=25 \
     JDBC_MAX_WAIT=30000 \
-    JDBC_INITIAL_SIZE=10 
+    JDBC_INITIAL_SIZE=10 \
+    JDBC_CONNECTION_PROPERTIES=''
 
 # Provide variables for the name of the rules, data, and customerdata schemas
 ENV RULES_SCHEMA=rules \

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ You can specify a variety settings for your connection to the database where Peg
 
 Name 						| Purpose 	| Default
 --- 						| --- 		| ---
-JDBC_MAX_ACTIVE 			| The maximum number of active connections that can be allocated from this pool at the same time. | `250`
-JDBC_MIN_IDLE 				| The minimum number of established connections that should be kept in the pool at all times. | `10`
-JDBC_MAX_IDLE 				| The maximum number of connections that should be kept in the pool at all times. | `50`
+JDBC_MAX_ACTIVE 			| The maximum number of active connections that can be allocated from this pool at the same time. | `75`
+JDBC_MIN_IDLE 				| The minimum number of established connections that should be kept in the pool at all times. | `3`
+JDBC_MAX_IDLE 				| The maximum number of connections that should be kept in the pool at all times. | `25`
 JDBC_MAX_WAIT 				| The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned before throwing an exception. | `30000`
-JDBC_INITIAL_SIZE 			| The initial number of connections that are created when the pool is started. | `50`
-JDBC_CONNECTION_PROPERTIES 	| The connection properties that will be sent to our JDBC driver when establishing new connections. Format of the string must be `[propertyName=property;]*`  | `socketTimeout=90`
+JDBC_INITIAL_SIZE 			| The initial number of connections that are created when the pool is started. | `10`
+JDBC_CONNECTION_PROPERTIES 	| The connection properties that will be sent to our JDBC driver when establishing new connections. Format of the string must be `[propertyName=property;]*`  | 
 
 ### Pega customization
 

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -19,6 +19,8 @@ metadataTest:
      value: 30000
    - key: JDBC_INITIAL_SIZE
      value: 10
+   - key: JDBC_CONNECTION_PROPERTIES
+     value: 
   exposedPorts: ["8080", "9001", "47100", "7003"]  
   # Add 5701-5710 ports                      
   entrypoint: [/scripts/docker-entrypoint.sh]

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -10,17 +10,15 @@ metadataTest:
    - key: PATH
      value: /usr/local/tomcat/bin:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    - key: JDBC_MAX_ACTIVE
-     value: 250
+     value: 75
    - key: JDBC_MIN_IDLE
-     value: 10
+     value: 3
    - key: JDBC_MAX_IDLE
-     value: 50
+     value: 25
    - key: JDBC_MAX_WAIT
      value: 30000
    - key: JDBC_INITIAL_SIZE
-     value: 50
-   - key: JDBC_CONNECTION_PROPERTIES
-     value: "socketTimeout=90"               
+     value: 10
   exposedPorts: ["8080", "9001", "47100", "7003"]  
   # Add 5701-5710 ports                      
   entrypoint: [/scripts/docker-entrypoint.sh]


### PR DESCRIPTION
Updating the JDBC connection properties to remove the default value of `socketTimeout=90`. This was causing problems in MSSQL deployments because the timeout of 90ms was too short.
Updating other JDBC configuration default settings as per the recommendation from Pega Cloud service teams and client feedback over the time.

Pega refs BUG-547108, SPACE-15322

_Edited by dcasavant_