### PR TITLE
US-325026 Defaulting JMX host name to use pod IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,7 @@ ENV MAX_THREADS="300" \
     NODE_SETTINGS=""
 
 # Configure Remote JMX support and bind to port 9001
-ENV JMX_PORT=9001 \
-    JMX_SERVER_HOSTNAME=127.0.0.1
+ENV JMX_PORT=9001
 
 # Configure Cassandra.
 ENV CASSANDRA_CLUSTER=false \

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -48,8 +48,7 @@ CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote"
 CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
 CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
 CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.ssl=false"
-CATALINA_OPTS="${CATALINA_OPTS} -Djava.rmi.server.hostname=${JMX_SERVER_HOSTNAME}"	
+CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.ssl=false"	
 
 # Setup SMA with auto discovery
 CATALINA_OPTS="${CATALINA_OPTS} -DSMAAutoNodeDiscovery=true "


### PR DESCRIPTION
This PR is to default the JMX Host name as the pod IP address and the changes should be backward compatible as well since defaulting to pod IP shouldn't restrict the access from the namespace or break any existing functionality. These changes are required to be made to support K8s upgrade-deploy action while the internals are mentioned and already discussed as part of story.