### PR TITLE
US-366965 Allow DB user/pass to be overridden

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -26,6 +26,9 @@ mkdir -p $lib_root
 config_root="${pega_root}/config"
 mkdir -p $config_root
 
+# Contains script for resolving alternative secrets
+source /scripts/secret_helper.sh
+
 secret_root="${pega_root}/secrets"
 mkdir -p $secret_root
 
@@ -34,8 +37,8 @@ prconfig="${config_root}/prconfig.xml"
 context_xml="${config_root}/context.xml"
 tomcatusers_xml="${config_root}/tomcat-users.xml"
 
-db_username_file="${secret_root}/DB_USERNAME"
-db_password_file="${secret_root}/DB_PASSWORD"
+db_username_file=$(resolveSecretPath "${secret_root}" "$DB_USERNAME_SECRET_PATH" "DB_USERNAME")
+db_password_file=$(resolveSecretPath "${secret_root}" "$DB_PASSWORD_SECRET_PATH" "DB_PASSWORD")
 
 cassandra_username_file="${secret_root}/CASSANDRA_USERNAME"
 cassandra_password_file="${secret_root}/CASSANDRA_PASSWORD"

--- a/scripts/secret_helper.sh
+++ b/scripts/secret_helper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+resolveSecretPath() {
+  defaultSecretPath=$1
+  alternateSecretPath=$2
+  secretName=$3
+
+  if [[ -e "${alternateSecretPath}/${secretName}" ]]; then
+    result="${alternateSecretPath}/${secretName}"
+  else
+    result="${defaultSecretPath}/${secretName}"
+  fi
+  echo "$result"
+}
+

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -481,6 +481,52 @@ commandTests:
     exitCode: 0
     expectedOutput: ["Database Password is - db_password_from_file"]
 
+    # Database Username with overridden file content   
+  - name: "Database Username with overridden file content"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_PASSWORD"
+      value: "postgres_pass"      
+    - key: "DB_USERNAME_SECRET_PATH"
+      value: "opt/pega/ext-secrets" 
+    command: "bash"
+    args:
+    - -c
+    - |
+        mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&    
+        mv tests/test-artifacts/DB_USERNAME /opt/pega/secrets/DB_USERNAME &&
+        mkdir -p /opt/pega/ext-secrets &&
+        mv tests/test-artifacts/DB_USERNAME_EXT /opt/pega/ext-secrets/DB_USERNAME &&
+        bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Database Username is - overridden_db_username"]
+
+    # Database Password with overridden file content
+  - name: "Database Password with overridden file content"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres_user"
+    - key: "DB_PASSWORD_SECRET_PATH"
+      value: "opt/pega/ext-secrets"      
+    command: "bash"
+    args:
+    - -c
+    - |
+        mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&    
+        mv tests/test-artifacts/DB_PASSWORD /opt/pega/secrets/DB_PASSWORD &&
+        mkdir -p /opt/pega/ext-secrets &&
+        mv tests/test-artifacts/DB_PASSWORD_EXT /opt/pega/ext-secrets/DB_PASSWORD &&
+        bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Database Password is - overridden_db_password"]
+
 # Cassandra Username as Environment Variable   
   - name: "Cassandra Username as Environment Variable"
     envVars:

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -491,7 +491,7 @@ commandTests:
     - key: "DB_PASSWORD"
       value: "postgres_pass"      
     - key: "DB_USERNAME_SECRET_PATH"
-      value: "opt/pega/ext-secrets" 
+      value: "/opt/pega/ext-secrets" 
     command: "bash"
     args:
     - -c
@@ -514,7 +514,7 @@ commandTests:
     - key: "DB_USERNAME"
       value: "postgres_user"
     - key: "DB_PASSWORD_SECRET_PATH"
-      value: "opt/pega/ext-secrets"      
+      value: "/opt/pega/ext-secrets"      
     command: "bash"
     args:
     - -c

--- a/tests/test-artifacts/DB_PASSWORD_EXT
+++ b/tests/test-artifacts/DB_PASSWORD_EXT
@@ -1,0 +1,1 @@
+overridden_db_password

--- a/tests/test-artifacts/DB_USERNAME_EXT
+++ b/tests/test-artifacts/DB_USERNAME_EXT
@@ -1,0 +1,1 @@
+overridden_db_username

--- a/tests/test-artifacts/catalina.sh
+++ b/tests/test-artifacts/catalina.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-pega_diagnostic_username_file="/opt/pega/secrets/PEGA_DIAGNOSTIC_USER"
-pega_diagnostic_password_file="/opt/pega/secrets/PEGA_DIAGNOSTIC_PASSWORD"
 
-db_username_file="/opt/pega/secrets/DB_USERNAME"
-db_password_file="/opt/pega/secrets/DB_PASSWORD"
+source /scripts/secret_helper.sh
+secret_root="/opt/pega/secrets"
 
-cassandra_username_file="/opt/pega/secrets/CASSANDRA_USERNAME"
-cassandra_password_file="/opt/pega/secrets/CASSANDRA_PASSWORD"
+pega_diagnostic_username_file="${secret_root}/PEGA_DIAGNOSTIC_USER"
+pega_diagnostic_password_file="${secret_root}/PEGA_DIAGNOSTIC_PASSWORD"
+
+db_username_file=$(resolveSecretPath "${secret_root}" "$DB_USERNAME_SECRET_PATH" "DB_USERNAME")
+db_password_file=$(resolveSecretPath "${secret_root}" "$DB_PASSWORD_SECRET_PATH" "DB_PASSWORD")
+
+cassandra_username_file="${secret_root}/CASSANDRA_USERNAME"
+cassandra_password_file="${secret_root}/CASSANDRA_PASSWORD"
 
 echo "$NODE_TYPE"
 


### PR DESCRIPTION
This is to allow overriding the secret path for DB_USERNAME and DB_PASSWORD so that we can use External Secrets.
We cannot provide External Secrets along the same path, so to use this functionality you must
- Mount a volume containing the secret
- Provide the path to this mounted volume via the Env var DB_USERNAME_SECRET_PATH or DB_PASSWORD_SECRET_PATH depending on which you are overriding
- Then the docker-entrypoint.sh script should handle choosing the overridden file if it exists along the (valid) filepath specified with the Env vars