### PR TITLE
Allow explicitly setting search deployment type

### DIFF
--- a/tomcat-conf/Catalina/localhost/prweb.xml
+++ b/tomcat-conf/Catalina/localhost/prweb.xml
@@ -6,6 +6,10 @@
        Ie, 'abc/feature1' and 'abc/feature1/threshold' can't be bound to objects.
   -->
   
+  {{ if .Env.PEGA_SEARCH_TYPE }}
+  <Environment name="prconfig/database/databases/pegasearch/searchDeploymentType" value="{{ .Env.PEGA_SEARCH_TYPE }}" type="java.lang.String" />
+  {{ end }}
+
   {{ if .Env.PEGA_SEARCH_URL }}
   <Environment name="prconfig/database/databases/pegasearch/searchEndpoint" value="{{ .Env.PEGA_SEARCH_URL }}" type="java.lang.String"/>
   {{ end }}


### PR DESCRIPTION
This change will allow testing with types other than the default.