### PR TITLE
Add support for customizing JMX connectivity (or disabling it).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ ENV MAX_THREADS="300" \
     PEGA_DEPLOYMENT_DIR=${CATALINA_HOME}/webapps/prweb
 
 # Configure Remote JMX support and bind to port 9001
-ENV JMX_PORT=9001 /
+ENV JMX_PORT=9001 \
     USE_CUSTOM_JMX_CONNECTION=
 
 # Configure Cassandra.

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,8 @@ ENV MAX_THREADS="300" \
     PEGA_DEPLOYMENT_DIR=${CATALINA_HOME}/webapps/prweb
 
 # Configure Remote JMX support and bind to port 9001
-ENV JMX_PORT=9001
+ENV JMX_PORT=9001 /
+    USE_CUSTOM_JMX_CONNECTION=
 
 # Configure Cassandra.
 ENV CASSANDRA_CLUSTER=false \

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -43,17 +43,15 @@ CATALINA_OPTS="${CATALINA_OPTS} -DNodeSettings=\"Pega-IntegrationEngine/EnableRe
 #  When left blank, disable indexing.
 CATALINA_OPTS="${CATALINA_OPTS} -Dindex.directory=${INDEX_DIRECTORY}"
 
-# Setup JMX
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote"
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
-CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.ssl=false"	
-
-# Setup SMA with auto discovery
-CATALINA_OPTS="${CATALINA_OPTS} -DSMAAutoNodeDiscovery=true "
-CATALINA_OPTS="${CATALINA_OPTS} -DSMAAutoNodeDiscoveryJMXPort=${JMX_PORT} "
-CATALINA_OPTS="${CATALINA_OPTS} -DSMAAutoNodeDiscoveryPort=8080 "
+# If not setting USE_CUSTOM_JMX_CONNECTION to "true", specify default JVM arguments for JMX
+if [ "${USE_CUSTOM_JMX_CONNECTION}" != "true" ]; then
+  # Setup OOTB JMX connectivity
+  CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote"
+  CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+  CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+  CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+  CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.ssl=false"	
+fi
 
 # Provide setting required for stream node 
 if [ "${IS_STREAM_NODE}" = "true" ]; then


### PR DESCRIPTION
This set of changes will allow JMX connectivity to be customized or completely disabled.  Customer environments may prefer to restrict JMX access according to the organizational mandates/security standards.  By default the original behavior persists if additional configuration is not provided.

To enable custom JMX connectivity, set the USE_CUSTOM_JMX_CONNECTION=true and provide JMX JVM arguments via the JAVA_OPTS env var.