### PR TITLE
US-391911-1:changes to support authentication in hz c/s mode in k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,9 @@ ENV PEGA_SEARCH_URL=
 ENV HZ_CLIENT_MODE=false \
     HZ_DISCOVERY_K8S= \
     HZ_CLUSTER_NAME= \
-    HZ_SERVER_HOSTNAME=
+    HZ_SERVER_HOSTNAME= \
+    HZ_CS_AUTH_USERNAME= \
+    HZ_CS_AUTH_PASSWORD=
 
 #Set up volume for persistent Kafka data storage
 RUN  mkdir -p /opt/pega/kafkadata && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,12 @@ ENV CASSANDRA_CLUSTER=false \
 # Configure search nodes. Empty string falls back to search being done on the nodes themselves.
 ENV PEGA_SEARCH_URL=
 
+# Configure hazelcast. By default, hazelcast runs in embedded mode.
+ENV HZ_CLIENT_MODE=false \
+    HZ_DISCOVERY_K8S= \
+    HZ_CLUSTER_NAME= \
+    HZ_SERVER_HOSTNAME=
+
 #Set up volume for persistent Kafka data storage
 RUN  mkdir -p /opt/pega/kafkadata && \
      chgrp -R 0 /opt/pega/kafkadata && \

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ HZ_CLIENT_MODE | Enables client mode for infinity  | `false`
 HZ_DISCOVERY_K8S | Indicates infinity client will use K8s discovery plugin to look for hazelcast nodes |
 HZ_CLUSTER_NAME| Hazelcast cluster name |
 HZ_SERVER_HOSTNAME| Hazelcast server hostname |
+HZ_CS_AUTH_USERNAME | Hazelcast username for authentication |
+HZ_CS_AUTH_PASSWORD | Hazelcast password for authentication |
 
 ## Image customizations
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ CASSANDRA_PORT		| C* port		| `9042`
 CASSANDRA_USERNAME	| C* username	|
 CASSANDRA_PASSWORD	| C* password	|
 
+
+### Hazelcast settings
+
+The clustering used in a Pega environment is powered by a technology called `Hazelcast`. Hazelcast can be used in an embedded mode with no additional configuration required.  Some larger deployments of more than 20 Pega containers may start to benefit from improved performance and stability of running Hazelcast in a dedicated ReplicaSet. For more information about deploying Pega with Hazelcast as an external server, see the Helm charts and the Pega Community documentation.
+
+Name 				| Purpose 		| Default
+--- 				| --- 			| ---
+HZ_CLIENT_MODE | Enables client mode for infinity  | `false`
+HZ_DISCOVERY_K8S | Indicates infinity client will use K8s discovery plugin to look for hazelcast nodes |
+HZ_CLUSTER_NAME| Hazelcast cluster name |
+HZ_SERVER_HOSTNAME| Hazelcast server hostname |
+
 ## Image customizations
 
 This Docker image extends the base image `pegasystems/tomcat:9-jdk11`. This has been thoroughly validated. You may choose change this to use your preferred Tomcat base image, however any change should be thoroughly tested and verified. Any problems that arise from changing the base of this image or customizing the contents of the ready image are not the responsibility of Pegasystems.

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -141,7 +141,7 @@ else
    export SECRET_HZ_CS_AUTH_PASSWORD=${HZ_CS_AUTH_PASSWORD}
 fi
 
-if [ "$CLIENT_MODE" = true ]; then
+if [ "HZ_CLIENT_MODE" = true ]; then
     if [ "$SECRET_HZ_CS_AUTH_USERNAME" == "" ] || [ "$SECRET_HZ_CS_AUTH_PASSWORD" == "" ]; then
         echo "HZ_CS_AUTH_USERNAME & HZ_CS_AUTH_PASSWORD must be specified in hazelcast client server mode deployments.";
         exit 1

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -141,7 +141,7 @@ else
    export SECRET_HZ_CS_AUTH_PASSWORD=${HZ_CS_AUTH_PASSWORD}
 fi
 
-if [ "HZ_CLIENT_MODE" = true ]; then
+if [ "HZ_CLIENT_MODE" == true ]; then
     if [ "$SECRET_HZ_CS_AUTH_USERNAME" == "" ] || [ "$SECRET_HZ_CS_AUTH_PASSWORD" == "" ]; then
         echo "HZ_CS_AUTH_USERNAME & HZ_CS_AUTH_PASSWORD must be specified in hazelcast client server mode deployments.";
         exit 1

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -43,6 +43,9 @@ cassandra_password_file="${secret_root}/CASSANDRA_PASSWORD"
 pega_diagnostic_username_file="${secret_root}/PEGA_DIAGNOSTIC_USER"
 pega_diagnostic_password_file="${secret_root}/PEGA_DIAGNOSTIC_PASSWORD"
 
+hazelcast_username_file="${secret_root}/HZ_CS_AUTH_USERNAME"
+hazelcast_password_file="${secret_root}/HZ_CS_AUTH_PASSWORD"
+
 # Define the JDBC_URL variable based on inputs
 if [ "$JDBC_URL" == "" ]; then
   echo "JDBC_URL must be specified.";
@@ -124,6 +127,25 @@ if [ -e "$cassandra_password_file" ]; then
    export SECRET_CASSANDRA_PASSWORD=$(<${cassandra_password_file})
 else
    export SECRET_CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}
+fi
+
+if [ -e "$hazelcast_username_file" ]; then
+   export SECRET_HZ_CS_AUTH_USERNAME=$(<${hazelcast_username_file})
+else
+   export SECRET_HZ_CS_AUTH_USERNAME=${HZ_CS_AUTH_USERNAME}
+fi
+
+if [ -e "$hazelcast_password_file" ]; then
+   export SECRET_HZ_CS_AUTH_PASSWORD=$(<${hazelcast_password_file})
+else
+   export SECRET_HZ_CS_AUTH_PASSWORD=${HZ_CS_AUTH_PASSWORD}
+fi
+
+if [ "$CLIENT_MODE" = true ]; then
+    if [ "$SECRET_HZ_CS_AUTH_USERNAME" == "" ] || [ "$SECRET_HZ_CS_AUTH_PASSWORD" == "" ]; then
+        echo "HZ_CS_AUTH_USERNAME & HZ_CS_AUTH_PASSWORD must be specified in hazelcast client server mode deployments.";
+        exit 1
+    fi
 fi
 
 /bin/dockerize -template ${CATALINA_HOME}/webapps/ROOT/index.html:${CATALINA_HOME}/webapps/ROOT/index.html
@@ -216,7 +238,7 @@ rm ${CATALINA_HOME}/conf/context.xml.tmpl
 rm ${CATALINA_HOME}/conf/tomcat-users.xml.tmpl
 
 
-unset DB_USERNAME DB_PASSWORD SECRET_DB_USERNAME SECRET_DB_PASSWORD CASSANDRA_USERNAME CASSANDRA_PASSWORD SECRET_CASSANDRA_USERNAME SECRET_CASSANDRA_PASSWORD PEGA_DIAGNOSTIC_USER PEGA_DIAGNOSTIC_PASSWORD SECRET_PEGA_DIAGNOSTIC_USER SECRET_PEGA_DIAGNOSTIC_PASSWORD PEGA_APP_CONTEXT_ROOT
+unset DB_USERNAME DB_PASSWORD SECRET_DB_USERNAME SECRET_DB_PASSWORD CASSANDRA_USERNAME CASSANDRA_PASSWORD SECRET_CASSANDRA_USERNAME SECRET_CASSANDRA_PASSWORD PEGA_DIAGNOSTIC_USER PEGA_DIAGNOSTIC_PASSWORD SECRET_PEGA_DIAGNOSTIC_USER SECRET_PEGA_DIAGNOSTIC_PASSWORD PEGA_APP_CONTEXT_ROOT HZ_CS_AUTH_USERNAME SECRET_HZ_CS_AUTH_USERNAME HZ_CS_AUTH_PASSWORD SECRET_HZ_CS_AUTH_PASSWORD
 
 unset pega_root lib_root config_root
 

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -883,7 +883,7 @@ commandTests:
     - key: "JDBC_URL"
       value: "jdbc:postgresql://localhost:5432/pegadb"
     - key: "JDBC_CLASS"
-       value: "org.postgresql.Driver"
+      value: "org.postgresql.Driver"
     - key: "DB_USERNAME"
       value: "postgres_user"
     - key: "DB_PASSWORD"

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -940,4 +940,4 @@ commandTests:
       mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&
       bash -c './scripts/docker-entrypoint.sh run'
     exitCode: 0
-    expectedOutput: ["Hazelcast Password is - hz_cs_auth_username"]
+    expectedOutput: ["Hazelcast Password is - hz_cs_auth_password"]

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -855,3 +855,89 @@ commandTests:
         bash -c './scripts/docker-entrypoint.sh'
     exitCode: 0
     expectedOutput: ["Loading prlog4j2 from /opt/pega/config/prlog4j2.xml"]
+
+  # Hazelcast Username as file input
+  - name: "Hazelcast Username as file input"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres_user"
+    - key: "DB_PASSWORD"
+      value: "postgres_pass"
+    command: "bash"
+    args:
+     - -c
+     - |
+        mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&
+        mv tests/test-artifacts/HZ_CS_AUTH_USERNAME /opt/pega/secrets/HZ_CS_AUTH_USERNAME &&
+        bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Hazelcast Username is - hazelcast_username_from_file"]
+
+  # Hazelcast Password as file input
+  - name: "Hazelcast Password as file input"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+       value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres_user"
+    - key: "DB_PASSWORD"
+      value: "postgres_pass"
+    command: "bash"
+    args:
+    - -c
+    - |
+      mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&
+      mv tests/test-artifacts/HZ_CS_AUTH_PASSWORD /opt/pega/secrets/HZ_CS_AUTH_PASSWORD &&
+      bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Hazelcast Password is - hazelcast_password_from_file"]
+
+  # Hazelcast Username as Environment Variable
+  - name: "Hazelcast Username as Environment Variable"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres_user"
+    - key: "DB_PASSWORD"
+      value: "postgres_pass"
+    - key: "HZ_CS_AUTH_USERNAME"
+      value: "hz_cs_auth_username"
+    command: "bash"
+    args:
+    - -c
+    - |
+      mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&
+      bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Hazelcast Username is - hz_cs_auth_username"]
+
+  # Hazelcast Password as Environment Variable
+  - name: "Hazelcast Password as Environment Variable"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres_user"
+    - key: "DB_PASSWORD"
+      value: "postgres_pass"
+    - key: "HZ_CS_AUTH_PASSWORD"
+      value: "hz_cs_auth_password"
+    command: "bash"
+    args:
+    - -c
+    - |
+      mv /tests/test-artifacts/catalina.sh /usr/local/tomcat/bin/catalina.sh &&
+      bash -c './scripts/docker-entrypoint.sh run'
+    exitCode: 0
+    expectedOutput: ["Hazelcast Password is - hz_cs_auth_username"]

--- a/tests/test-artifacts/HZ_CS_AUTH_PASSWORD
+++ b/tests/test-artifacts/HZ_CS_AUTH_PASSWORD
@@ -1,0 +1,1 @@
+hazelcast_password_from_file

--- a/tests/test-artifacts/HZ_CS_AUTH_USERNAME
+++ b/tests/test-artifacts/HZ_CS_AUTH_USERNAME
@@ -1,0 +1,1 @@
+hazelcast_username_from_file

--- a/tests/test-artifacts/catalina.sh
+++ b/tests/test-artifacts/catalina.sh
@@ -8,6 +8,9 @@ db_password_file="/opt/pega/secrets/DB_PASSWORD"
 cassandra_username_file="/opt/pega/secrets/CASSANDRA_USERNAME"
 cassandra_password_file="/opt/pega/secrets/CASSANDRA_PASSWORD"
 
+hazelcast_username_file="/opt/pega/secrets/HZ_CS_AUTH_USERNAME"
+hazelcast_password_file="/opt/pega/secrets/HZ_CS_AUTH_PASSWORD"
+
 echo "$NODE_TYPE"
 
 echo "Index Directory Value - $INDEX_DIRECTORY"
@@ -31,6 +34,22 @@ fi
 echo "Cassandra Username is - $SECRET_CASSANDRA_USERNAME"
 
 echo "Cassandra Password is - $SECRET_CASSANDRA_PASSWORD"
+
+if [ -e "$hazelcast_username_file" ]; then
+    export SECRET_HAZELCAST_USERNAME=$(<${hazelcast_username_file})
+else
+    export SECRET_HAZELCAST_USERNAME=hz_cs_auth_username
+fi
+
+if [ -e "$hazelcast_password_file" ]; then
+    export SECRET_HAZELCAST_PASSWORD=$(<${hazelcast_password_file})
+else
+    export SECRET_HAZELCAST_PASSWORD=hz_cs_auth_password
+fi
+
+echo "Hazelcast Username is - $SECRET_HAZELCAST_USERNAME"
+
+echo "Hazelcast Password is - $SECRET_HAZELCAST_PASSWORD"
 
 if [ -e "$db_username_file" ]; then
    export SECRET_DB_USERNAME=$(<${db_username_file})

--- a/tomcat-conf/Catalina/localhost/prweb.xml
+++ b/tomcat-conf/Catalina/localhost/prweb.xml
@@ -38,6 +38,8 @@
   <Environment name="prconfig/cluster/clientserver/hzOnK8s" value="{{ .Env.HZ_DISCOVERY_K8S }}" type="java.lang.String"/>
   <Environment name="prconfig/identification/cluster/name" value="{{ .Env.HZ_CLUSTER_NAME }}" type="java.lang.String"/>
   <Environment name="prconfig/cluster/clientserver/server/hostname" value="{{ .Env.HZ_SERVER_HOSTNAME }}" type="java.lang.String"/>
+  <Environment name="prconfig/cluster/clientserver/authentication/username" value="{{ .Env.SECRET_HZ_CS_AUTH_USERNAME }}" type="java.lang.String"/>
+  <Environment name="prconfig/cluster/clientserver/authentication/password" value="{{ .Env.SECRET_HZ_CS_AUTH_PASSWORD }}" type="java.lang.String"/>
   {{ end }}
   
 </Context>

--- a/tomcat-conf/Catalina/localhost/prweb.xml
+++ b/tomcat-conf/Catalina/localhost/prweb.xml
@@ -32,5 +32,12 @@
   <Environment name="prconfig/session/ha/enabled" value="true" type="java.lang.String"/>
   <Environment name="prconfig/dsm/services/stream/pyBaseLogPath" value="/opt/pega/kafkadata" type="java.lang.String" />
   <Environment name="prconfig/cloud/isNodeAgnosticAdminStudio" value="true" type="java.lang.String"/>
+
+  {{ if isTrue .Env.HZ_CLIENT_MODE }}
+  <Environment name="prconfig/cluster/clientserver/clientmode" value="{{ .Env.HZ_CLIENT_MODE }}" type="java.lang.String"/>
+  <Environment name="prconfig/cluster/clientserver/hzOnK8s" value="{{ .Env.HZ_DISCOVERY_K8S }}" type="java.lang.String"/>
+  <Environment name="prconfig/identification/cluster/name" value="{{ .Env.HZ_CLUSTER_NAME }}" type="java.lang.String"/>
+  <Environment name="prconfig/cluster/clientserver/server/hostname" value="{{ .Env.HZ_SERVER_HOSTNAME }}" type="java.lang.String"/>
+  {{ end }}
   
 </Context>


### PR DESCRIPTION
Changes to support hz c/s authentication. We take username and password, and create secrets out of this and mount volumes created out of these secrets on container files. Tomcat gets these values through prweb.xml only when hz c/s mode is enabled.

