### PR TITLE
Default overrideable and non-overrideable parameters for JVM tunability

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -29,8 +29,6 @@ JAVA_OPTS="-Xms${INITIAL_HEAP} -Xmx${MAX_HEAP} ${JAVA_OPTS}"
 echo JAVA_OPTS: \"${JAVA_OPTS}\"
 export  JAVA_OPTS
 
-CATALINA_OPTS=""
-
 # Tomcat Listener Settings
 CATALINA_OPTS="${CATALINA_OPTS} -DmaxThreads=${MAX_THREADS}"
 
@@ -59,6 +57,14 @@ if [ "${IS_STREAM_NODE}" = "true" ]; then
   CATALINA_OPTS="${CATALINA_OPTS} -Dprconfig/dsm/services/stream/pyUnpackBasePath/tmp/kafka "
   CATALINA_OPTS="${CATALINA_OPTS} -Dprconfig/dsm/services/stream/server_properties/unclean.leader.election.enable=false "
 fi
+
+# recommended non-overridable  JVM Arguments
+CATALINA_OPTS="${CATALINA_OPTS} -XX:+DisableExplicitGC"
+CATALINA_OPTS="${CATALINA_OPTS} -Djava.security.egd=file:///dev/urandom"
+CATALINA_OPTS="${CATALINA_OPTS} -XX:+CrashOnOutOfMemoryError"
+# recommended overridable JVM Arguments 
+CATALINA_OPTS="-XX:+UseStringDeduplication ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M ${CATALINA_OPTS}"
 
 echo CATALINA_OPTS: \"${CATALINA_OPTS}\"
 

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -61,7 +61,7 @@ fi
 # recommended non-overridable  JVM Arguments
 CATALINA_OPTS="${CATALINA_OPTS} -XX:+DisableExplicitGC"
 CATALINA_OPTS="${CATALINA_OPTS} -Djava.security.egd=file:///dev/urandom"
-CATALINA_OPTS="${CATALINA_OPTS} -XX:+CrashOnOutOfMemoryError"
+CATALINA_OPTS="${CATALINA_OPTS} -XX:+ExitOnOutOfMemoryError"
 # recommended overridable JVM Arguments 
 CATALINA_OPTS="-XX:+UseStringDeduplication ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M ${CATALINA_OPTS}"


### PR DESCRIPTION
For better tunability of JVM Pega recommends defaults for some of the JVM arguments.
Here, these parameters can be set as **CATALINA_OPTS**. Earlier,  **CATALINA_OPTS** environment variable was not exposed to set externally as it is always initialized to an empty string(""). Removed this to expose the CATALANA_OPTS.
Added two sets of JVM arguments:
1. The arguments which are not overridden and are absolute defaults.   
2. The arguments with the flexibility to override by setting the environment variable externally. 