### PR TITLE
BUG-622973 : Remove jdk8 unsupported JVM arguments

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -64,7 +64,6 @@ CATALINA_OPTS="${CATALINA_OPTS} -Djava.security.egd=file:///dev/urandom"
 CATALINA_OPTS="${CATALINA_OPTS} -XX:+ExitOnOutOfMemoryError"
 # recommended overridable JVM Arguments 
 CATALINA_OPTS="-XX:+UseStringDeduplication ${CATALINA_OPTS}"
-CATALINA_OPTS="-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M ${CATALINA_OPTS}"
 
 echo CATALINA_OPTS: \"${CATALINA_OPTS}\"
 


### PR DESCRIPTION
Currently, SDEA uses jdk8 and the unified GC logging format is supported from jdk9, hence breaking their environments. 
https://openjdk.java.net/jeps/271
Earlier, our assumption was that the consumers of this image use jdk11. 
Removed the flag for the same purpose. 