### PR TITLE
Don't show version or stacktrace on error pages

### DIFF
--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -169,6 +169,10 @@
                pattern="%{X-Forwarded-For}i %h %l %u %t &quot;%r&quot; %s %b" 
                resolveHosts="false" />
 
+        <Valve className="org.apache.catalina.valves.ErrorReportValve"
+               showReport="false" 
+               showServerInfo="false" />
+
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
Resolves #101 

This PR flips the `showReport` and `showServerInfo` flags to false on the default `ErrorReportValve` so that the error pages only contain the header with the HTTP status info.