### PR TITLE
Added jvm9+ supported GC logs JVM argument

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -64,6 +64,7 @@ CATALINA_OPTS="${CATALINA_OPTS} -Djava.security.egd=file:///dev/urandom"
 CATALINA_OPTS="${CATALINA_OPTS} -XX:+ExitOnOutOfMemoryError"
 # recommended overridable JVM Arguments 
 CATALINA_OPTS="-XX:+UseStringDeduplication ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M ${CATALINA_OPTS}"
 
 echo CATALINA_OPTS: \"${CATALINA_OPTS}\"
 


### PR DESCRIPTION
This includes a change(related to GC logs JVM argument) from https://github.com/pegasystems/docker-pega-web-ready/pull/95 which was then reverted in   https://github.com/pegasystems/docker-pega-web-ready/pull/96 because of SDEA being using java8. Now that SDEA has moved to java11 this should not be a problem. 