### PR TITLE
Removed empty check for DB_PASSWORD

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -204,8 +204,8 @@ else
        export SECRET_DB_PASSWORD=${DB_PASSWORD}
     fi
 
-    if [ "$SECRET_DB_USERNAME" == "" ] || [ "$SECRET_DB_PASSWORD" == "" ] ; then
-      echo "DB_USERNAME and DB_PASSWORD must be specified.";
+    if [ "$SECRET_DB_USERNAME" == "" ] ; then
+      echo "DB_USERNAME must be specified.";
       exit 1
     fi
 

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -1001,3 +1001,32 @@ commandTests:
       bash -c './scripts/docker-entrypoint.sh run'
     exitCode: 0
     expectedOutput: ["Hazelcast Password is - hz_cs_auth_password"]
+  # Verify empty DB_USERNAME
+  - name: "Empty DB_USERNAME check fails"
+    envVars:
+      - key: "JDBC_URL"
+        value: "jdbc:postgresql://localhost:5432/pegadb"
+      - key: "JDBC_CLASS"
+        value: "org.postgresql.Driver"
+    command: "bash"
+    args:
+      - -c
+      - |
+        bash -c './scripts/docker-entrypoint.sh'
+    exitCode: 1
+    expectedOutput: ["DB_USERNAME must be specified."]
+  # Verify empty DB_PASSWORD as DB_PASSWORD is no longer mandatory with AWS Secrets
+  - name: "Empty DB_PASSWORD check passes"
+    envVars:
+      - key: "JDBC_URL"
+        value: "jdbc:postgresql://localhost:5432/pegadb"
+      - key: "JDBC_CLASS"
+        value: "org.postgresql.Driver"
+      - key: "DB_USERNAME"
+        value: "postgres"
+    command: "bash"
+    args:
+      - -c
+      - |
+        bash -c './scripts/docker-entrypoint.sh'
+    expectedOutput: ["No context.xml was specified"]


### PR DESCRIPTION
"docker-pega-web-ready" by default does not accept empty db_password.  So, we removed that check here and added test case for the same.  

An issue was raised that the passwords are in plaintext format in context.xml inside the container.  So, we are mitigating this by leveraging aws-secret-manager-jdbc to contact aws and fetch secret value to establish a DB connection.  When going by this method, password is no longer mandatory.

This will be leveraged by pega-cloud.