### PR TITLE
Adding applicableNodeTypes params

### DIFF
--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -51,6 +51,12 @@ if [ "${USE_CUSTOM_JMX_CONNECTION}" != "true" ]; then
   CATALINA_OPTS="${CATALINA_OPTS} -Dcom.sun.management.jmxremote.ssl=false"	
 fi
 
+# Add applicable node types if it is not empty
+#
+if [[ ! -z  ${APPLICABLE_NODE_TYPES} ]]; then
+	CATALINA_OPTS=" ${CATALINA_OPTS} -DapplicableNodeTypes=${APPLICABLE_NODE_TYPES} "
+fi
+
 # Provide setting required for stream node 
 if [ "${IS_STREAM_NODE}" = "true" ]; then
   CATALINA_OPTS="${CATALINA_OPTS} -Dprconfig/dsm/services=StreamServer "


### PR DESCRIPTION
PegaMKTSMS and PegaMKTEmail are Valid NodeTypes for CDH Deployments. when i set -DNodeType to PegaMKTSMS and PegaMKTEmail it display below message:
 
{"app":"","stack":"","@timestamp":"2020-11-10T08:32:41.991Z","source_host":"pega-web-665cd9c678-2fbwl","level":"ERROR","thread_name":"main","@version":1,"tenantid":"","logger_name":"com.pega.platform.environment.nodeclassification.internal.NodeClassificationImpl","message":"Node cannot start with invalid NodeType passed: PegaMKTEmail. Or it is not specified in applicableNodeTypes","userid":"","pegathread":""}
its invalid nodetype the valid applicable NodeTypes are [Search, WebUser, BIX, BackgroundProcessing, Custom1, Custom2, Custom3, Custom4, Custom5, DDS, ADM, Batch, RealTime, RTDG, Stream]

 As of now there is no way to pass the ApplicableNodeTypes environment value to tomcat.

Introducing ApplicableNodeTypes param in tomcat will able to fix the above issue and can pass customNodeTypes as well.
 