### PR TITLE
Add http connector on port 8081 for liveliness check.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ CMD ["run"]
 
 # Expose required ports
 
-# HTTP is 8080, 8081 is for k8s liveliness, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
+# HTTP is 8080, 8081 is for k8s liveness, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
 EXPOSE 8080, 8081, 9001 9090 5701-5710 47100 7003
 
 # *****Target for test environment*****

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,8 +186,8 @@ CMD ["run"]
 
 # Expose required ports
 
-# HTTP is 8080, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
-EXPOSE 8080 9001 9090 5701-5710 47100 7003
+# HTTP is 8080, 8081 is for k8s liveliness, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
+EXPOSE 8080, 8081, 9001 9090 5701-5710 47100 7003
 
 # *****Target for test environment*****
 

--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -70,7 +70,7 @@
                connectionTimeout="20000"
                redirectPort="8443" />
                
-    <!-- facilitates liveliness check via separate port -->           
+    <!-- facilitates liveness check via separate port -->           
     <Connector port="8081" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443"

--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -69,6 +69,13 @@
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443" />
+               
+    <!-- facilitates liveliness check via separate port -->           
+    <Connector port="8081" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443"
+               maxThreads="1" />
+               
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
Adding a separate HTTP connector on port 8081 to respond to liveliness checks from kubernetes.