### PR TITLE
Remove all references to MAX_THREADS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,8 +95,7 @@ ENV PEGA_DIAGNOSTIC_USER='' \
     PEGA_DIAGNOSTIC_PASSWORD=''
 
 # Parameterize variables to customize the tomcat runtime
-ENV MAX_THREADS="300" \
-    JAVA_OPTS="" \
+ENV JAVA_OPTS="" \
     MAX_HEAP="4096m" \
     INITIAL_HEAP="2048m" \
     INDEX_DIRECTORY="NONE" \

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Name 			| Purpose 	| Default
 --- 			| --- 		| ---
 PEGA_APP_CONTEXT_PATH   | The application context path that Tomcat uses to direct traffic to the Pega application | prweb
 PEGA_DEPLOYMENT_DIR   | The location of the Pega app deployment | /usr/local/tomcat/webapps/prweb
-MAX_THREADS 	| The max number of active threads in this pool using Tomcat's `maxThreads` setting. | `300`
 JAVA_OPTS 		| Specify any additional parameters that should be appended to the `java` command. |
 INITIAL_HEAP 	| Specify the initial size (`Xms`) of the java heap. | `2048m`
 MAX_HEAP 		| Specify the maximum size (`Xmx`) of the java heap. | `4096m`

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -29,9 +29,6 @@ JAVA_OPTS="-Xms${INITIAL_HEAP} -Xmx${MAX_HEAP} ${JAVA_OPTS}"
 echo JAVA_OPTS: \"${JAVA_OPTS}\"
 export  JAVA_OPTS
 
-# Tomcat Listener Settings
-CATALINA_OPTS="${CATALINA_OPTS} -DmaxThreads=${MAX_THREADS}"
-
 # Node settings
 CATALINA_OPTS="${CATALINA_OPTS} -Didentification.nodeid=${HOSTNAME}"
 CATALINA_OPTS="${CATALINA_OPTS} -DNodeType=${NODE_TYPE}"


### PR DESCRIPTION
The documentation in this repo claims that the pega web container supports the ability to configure the 8080 connector's maxThreads, and indicates that if the client doesn't set the value, the default will be 300.  The image, however, doesn't honor this setting and instead always uses Tomcat's default of 200.  After some investigation, it appears that the [previous way of setting maxThreads](https://github.com/pegasystems/docker-pega-web-ready/blob/65a822bf41bbddf5d30465942ca4e3f146c67681/tomcat-bin/setenv.sh#L33) wasn't having any effect and isn't supported by Tomcat.  Instead, this property should be set on the connector in server.xml.  

Given that server.xml is now supplied by our helm templates and a direct docker run of this container isn't supported, I think it's best to just delete all references to MAX_THREADS to avoid confusion.

(Internal BUG-656180)