### PR TITLE
Update prometheus jar version to address CVE-2017-18640

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ RUN  mkdir -p /opt/pega/kafkadata && \
 
 # Set up dir for prometheus lib
 RUN mkdir -p /opt/pega/prometheus && \
-    curl -sL -o /opt/pega/prometheus/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.15.0/jmx_prometheus_javaagent-0.15.0.jar && \
+    curl -sL -o /opt/pega/prometheus/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar && \
     chgrp -R 0 /opt/pega/prometheus && \
     chmod -R g+rw /opt/pega/prometheus && \
     chown -R pegauser /opt/pega/prometheus && \


### PR DESCRIPTION
This PR updates the jmx_prometheus_javaagent jar from 0.15.0 to 0.16.1 to address CVE-2017-18640.

See this release from prometheus: https://github.com/prometheus/jmx_exporter/releases/tag/parent-0.16.0. Note that, this CVE is not a relevant vulnerability according to prometheus:

> This vulnerability does not apply in the context of jmx_exporter, because the agent configuration will not come from an untrusted source. However, even if there is no actual security risk, users find it annoying that their automated security scans report a CVE. In order to prevent this we published a version with an updated snakeyaml dependency that requires Java >= 7.

Similarly, we should update our jmx_prometheus_javaagent jar so that customers do not detect this vulnerability during scans.