### PR TITLE
Also allow Temurin for version check

### DIFF
--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -166,8 +166,8 @@ commandTests:
     args:
     - -c
     - |
-        java -version  2>&1 | grep "OpenJDK 64-Bit Server VM AdoptOpenJDK"
-    expectedOutput: [".*OpenJDK 64-Bit Server VM AdoptOpenJDK.*"] 
+        java -version  2>&1 | grep -E "OpenJDK 64-Bit Server VM (AdoptOpenJDK|Temurin)"
+    expectedOutput: [".*OpenJDK 64-Bit Server VM (AdoptOpenJDK|Temurin).*"] 
 # Verify Cataline_home variable       
   - name: "Catalina Home check"
     command: "echo"


### PR DESCRIPTION
AdoptOpenJDK has recently rebranded to Eclipse Temurin.  In order to
switch the base image over to versions with the new name, we need to
relax the version check so that it accepts both versions