### PR TITLE
Disable autoDeploy feature

### DIFF
--- a/tests/test-artifacts/templates/expected_server.xml
+++ b/tests/test-artifacts/templates/expected_server.xml
@@ -171,7 +171,7 @@
       </Realm>
 
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
+            unpackWARs="true" autoDeploy="false">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->

--- a/tests/test-artifacts/templates/server.xml.tmpl
+++ b/tests/test-artifacts/templates/server.xml.tmpl
@@ -173,7 +173,7 @@
       </Realm>
 
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
+            unpackWARs="true" autoDeploy="false">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->

--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -150,7 +150,7 @@
       </Realm>
 
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
+            unpackWARs="true" autoDeploy="false">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
Disabling autoDeploy in tomcat as it is a feature that is not leveraged by pega deployments.