### PR TITLE
ISSUE-187: add maxDays to AccessLogValve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ ENV JAVA_OPTS="" \
     MAX_HEAP="4096m" \
     INITIAL_HEAP="2048m" \
     INDEX_DIRECTORY="NONE" \
+    ACCESS_LOG_MAX_DAYS="-1" \
     HEAP_DUMP_PATH="/heapdumps" \
     NODE_TYPE="" \
     NODE_TIER="" \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ JAVA_OPTS 		| Specify any additional parameters that should be appended to the `
 INITIAL_HEAP 	| Specify the initial size (`Xms`) of the java heap. | `2048m`
 MAX_HEAP 		| Specify the maximum size (`Xmx`) of the java heap. | `4096m`
 HEAP_DUMP_PATH 	| Specify a location for a heap dump using `XX:HeapDumpPath` | `/heapdumps`
+ACCESS_LOG_MAX_DAYS | Specify the maximum number of days rotated access logs will be retained for before being deleted. | `-1`
 
 
 ### Cassandra settings

--- a/tomcat-bin/setenv.sh
+++ b/tomcat-bin/setenv.sh
@@ -80,6 +80,7 @@ fi
 CATALINA_OPTS="${CATALINA_OPTS} -XX:+DisableExplicitGC"
 CATALINA_OPTS="${CATALINA_OPTS} -Djava.security.egd=file:///dev/urandom"
 CATALINA_OPTS="${CATALINA_OPTS} -XX:+ExitOnOutOfMemoryError"
+CATALINA_OPTS="${CATALINA_OPTS} -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"
 # recommended overridable JVM Arguments 
 CATALINA_OPTS="-XX:+UseStringDeduplication ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M ${CATALINA_OPTS}"

--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -164,7 +164,7 @@
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log" suffix=".txt"
+               prefix="localhost_access_log" suffix=".txt" maxDays="${ACCESS_LOG_MAX_DAYS}"
                pattern="%{X-Forwarded-For}i %h %l %u %t &quot;%r&quot; %s %b" 
                resolveHosts="false" />
 


### PR DESCRIPTION
Implemented the ability to configure the rotation of the tomcat access log using the attribute [maxDays](https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve/Attributes).

The default value of -1 will be used, which means never deleting old files. This mirrors the existing behaviour when not specifying the maxDays attribute.