### PR TITLE
updated upload-sarif GitHub action from v1 to v2.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -81,7 +81,7 @@ jobs:
         path: ${{ steps.scan.outputs.sarif }}
         
     - name: Upload Anchore Scan SARIF Report
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}
 


### PR DESCRIPTION
v1 of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported. For better performance, improved security, and new features, upgrade to v2. For more information, see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/