### PR TITLE
US-583793-2 - Handling failing of package download

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -63,7 +63,6 @@ catalina_properties="${final_config_root}/catalina.properties"
 prbootstrap_properties="${final_config_root}/prbootstrap.properties"
 java_security_overwrite="${final_config_root}/java.security.overwrite"
 tomcat_web_xml="${final_config_root}/tomcat-web.xml"
-file_setting_download_script="${lib_root}/filesettingdownload.sh"
 
 declare -a secrets_list=("DB_USERNAME" "DB_PASSWORD" "CUSTOM_ARTIFACTORY_USERNAME" "CUSTOM_ARTIFACTORY_PASSWORD" "CUSTOM_ARTIFACTORY_APIKEY_HEADER" "CUSTOM_ARTIFACTORY_APIKEY" "CASSANDRA_USERNAME" "CASSANDRA_PASSWORD" "CASSANDRA_TRUSTSTORE_PASSWORD" "CASSANDRA_KEYSTORE_PASSWORD"  "HZ_CS_AUTH_USERNAME" "HZ_CS_AUTH_PASSWORD" "PEGA_DIAGNOSTIC_USER" "PEGA_DIAGNOSTIC_PASSWORD" "STREAM_TRUSTSTORE_PASSWORD" "STREAM_KEYSTORE_PASSWORD" "STREAM_JAAS_CONFIG")
 for secret in "${secret_root}"/*
@@ -131,14 +130,6 @@ if [[ "$custom_artifactory_auth" == "" && ( "$SECRET_CUSTOM_ARTIFACTORY_APIKEY_H
         echo "Using API key for authentication of custom artifactory to download JDBC driver."
         custom_artifactory_auth="-H "$SECRET_CUSTOM_ARTIFACTORY_APIKEY_HEADER":"$SECRET_CUSTOM_ARTIFACTORY_APIKEY
     fi
-fi
-
-#for file settings in pega cloudk
-if [ -e "$file_setting_download_script" ]; then
-  echo "file setting script does exists"
-  (cd $pega_root ; sh "$file_setting_download_script")
-else
-   echo "file setting script does not exist"
 fi
 
 custom_artifactory_certificate=''


### PR DESCRIPTION
This checks if file settings archive script exists in file system, if yes, it runs the script. if there is any error, it fails the pod startup. This is specifically for pega cloudk

Reverting the above changes done in the #201  as this logic should be present in different repository. This pr has a dependency with docker-pega PR. Both PRs should be merged together to have the feature available.