### PR TITLE
US-614190: Stale action workflow to handle for github repo issues & PR's with no activity

### DIFF
--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -19,7 +19,7 @@ jobs:
           only-labels: 'pending info' # only mark issues/PRs as stale if they have this label
           labels-to-remove-when-unstale: 'pending info' # remove label when unstale -- should be manually added back if information is insufficient
           # automated messages to issue/PR authors
-          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This pull request is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment or this will be closed in 7 days.'
+          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment if you want to address this issue otherwise this will be closed in 7 days.'
+          stale-pr-message: 'This pull request is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or address review comments and update the pull request otherwise this will be closed in 7 days.'
           close-issue-message: 'This issue has been closed due to inactivity and lack of information.If you still encounter this issue, please add the requested information and re-open.'
           close-pr-message: 'This PR has been closed due to inactivity and lack of changes.If you would like to still work on this PR, please address the review comments and re-open.'

--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+on:
+  schedule:
+    - cron: '0 23 * * *' # once a day at 11pm UTC time zone
+jobs:
+  stale:
+    permissions:
+      issues: write # for commenting on an issue and editing labels
+      pull-requests: write # for commenting on a PR and editing labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # timing
+          days-before-stale: 60 # 60 days of inactivity
+          days-before-close: 7 # 7 more days of inactivity
+          # labels to watch for, add, and remove
+          only-labels: 'pending info' # only mark issues/PRs as stale if they have this label
+          labels-to-remove-when-unstale: 'pending info' # remove label when unstale -- should be manually added back if information is insufficient
+          # automated messages to issue/PR authors
+          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This pull request is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue has been closed due to inactivity and lack of information.If you still encounter this issue, please add the requested information and re-open.'
+          close-pr-message: 'This PR has been closed due to inactivity and lack of changes.If you would like to still work on this PR, please address the review comments and re-open.'

--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -14,12 +14,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # timing
           days-before-stale: 60 # 60 days of inactivity
-          days-before-close: 7 # 7 more days of inactivity
+          days-before-close: 30 # 30 more days of inactivity
           # labels to watch for, add, and remove
           only-labels: 'pending info' # only mark issues/PRs as stale if they have this label
           labels-to-remove-when-unstale: 'pending info' # remove label when unstale -- should be manually added back if information is insufficient
           # automated messages to issue/PR authors
-          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or comment if you want to address this issue otherwise this will be closed in 7 days.'
-          stale-pr-message: 'This pull request is marked as stale because it has been open 60 days with no activity. Remove pending info & stale labels or address review comments and update the pull request otherwise this will be closed in 7 days.'
-          close-issue-message: 'This issue has been closed due to inactivity and lack of information.If you still encounter this issue, please add the requested information and re-open.'
-          close-pr-message: 'This PR has been closed due to inactivity and lack of changes.If you would like to still work on this PR, please address the review comments and re-open.'
+          stale-issue-message: 'This issue has been marked as stale because it has been open for 60 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been open for 60 days with no activity. This pull request will be automatically closed in 30 days if no further activity occurs.'
+          close-issue-message: 'This issue was closed because it has been inactive for 30 days since being marked as stale.'
+          close-pr-message: 'This pull request was closed because it has been inactive for 30 days since being marked as stale.'


### PR DESCRIPTION
1: Stale action workflow to handle github repo issues & pull requests with no activity for more than 60 days which are labelled with pending info and it will be marked as stale.
2: Stale issues & PR's will proceed for closing with respective comments, if it doesn't receive any activity with in 7 days after making it as stale . 