### PR TITLE
US-620855 Add detemplatize executable using multi stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd -g 9001 pegauser && \
 
 
 ENV PEGA_DOCKER_VERSION=${VERSION:-CUSTOM_BUILD}
-
+# Copy detemplatize to base image bin directory
 COPY --from=detemplatize /bin/detemplatize /bin/detemplatize
 
 COPY hashes/ /hashes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile for Pega 8 Platform
 
 # Base image to extend from
-
 ARG BASE_TOMCAT_IMAGE
 
 FROM pegasystems/detemplatize:latest as detemplatize
+
 FROM $BASE_TOMCAT_IMAGE as release
 
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 # Base image to extend from
 
 ARG BASE_TOMCAT_IMAGE
+
+FROM pegasystems/detemplatize:latest as detemplatize
 FROM $BASE_TOMCAT_IMAGE as release
 
 ARG VERSION
@@ -18,6 +20,8 @@ RUN groupadd -g 9001 pegauser && \
 
 
 ENV PEGA_DOCKER_VERSION=${VERSION:-CUSTOM_BUILD}
+
+COPY --from=detemplatize /bin/detemplatize /bin/detemplatize
 
 COPY hashes/ /hashes/
 COPY keys/ /keys/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Base image to extend from
 ARG BASE_TOMCAT_IMAGE
 
-FROM pegasystems/detemplatize:latest as detemplatize
+FROM pegasystems/detemplatize as detemplatize
 
 FROM $BASE_TOMCAT_IMAGE as release
 

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -9,20 +9,8 @@ Pega provides a pega-web-ready Docker image using Tomcat 9 and JDK 11 as a base 
 To build a custom pega-web-ready image using your preferred OS and JDK, perform the following actions:
 
 1. Create a Dockerfile for your custom pega-web-ready image using your base image.
-     
-   a. Use multi-stage Docker build at the beginning of your Dockerfile to copy the detemplatize executive file from the `pegasystems/detemplatize` Docker image to your base image.
-      The detemplatize executive file replaces template variables with actual values in the Pega Platform code.
-
-   For example:
-      ```Dockerfile
-      FROM pegasystems/detemplatize AS builder
-      # Base Image to be used to build pega-ready image 
-      FROM <BASE_IMAGE>
-      # Copy detemplatize to base image bin directory
-      COPY --from=builder /bin/detemplatize /bin/detemplatize 
-      ```
    
-   b. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
+   a. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
       For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
       Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.
 

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -8,7 +8,9 @@ Prerequisites:
 Pega provides a pega-web-ready Docker image using Tomcat 9 and JDK 11 as a base image. For more information about the pega-web-ready Docker image, see `pegasystems/docker-pega-web-ready`
 To build a custom pega-web-ready image using your preferred OS and JDK, perform the following actions:
 
-1. Create a Dockerfile for your custom pega-web-ready image using your base image and the open-source pega-web-ready Dockerfile code.
+1. Create a Dockerfile for your custom pega-web-ready image using your base image and the open-source pega-web-ready Dockerfile code. 
+   For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
+   Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.
 
 2. Use the following command to build the custom pega-web-ready image using the base image as an argument.
      ```bash

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -8,11 +8,7 @@ Prerequisites:
 Pega provides a pega-web-ready Docker image using Tomcat 9 and JDK 11 as a base image. For more information about the pega-web-ready Docker image, see `pegasystems/docker-pega-web-ready`
 To build a custom pega-web-ready image using your preferred OS and JDK, perform the following actions:
 
-1. Create a Dockerfile for your custom pega-web-ready image using your base image.
-   
-   a. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
-      For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
-      Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.
+1. Create a Dockerfile for your custom pega-web-ready image using your base image and the open-source pega-web-ready Dockerfile code.
 
 2. Use the following command to build the custom pega-web-ready image using the base image as an argument.
      ```bash

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -9,7 +9,7 @@ Pega provides a pega-web-ready Docker image using Tomcat 9 and JDK 11 as a base 
 To build a custom pega-web-ready image using your preferred OS and JDK, perform the following actions:
 
 1. Create a Dockerfile for your custom pega-web-ready image using your base image.
-   
+     
    a. Use multi-stage Docker build at the beginning of your Dockerfile to copy the detemplatize executive file from the `pegasystems/detemplatize` Docker image to your base image.
       The detemplatize executive file replaces template variables with actual values in the Pega Platform code.
 
@@ -21,7 +21,7 @@ To build a custom pega-web-ready image using your preferred OS and JDK, perform 
       # Copy detemplatize to base image bin directory
       COPY --from=builder /bin/detemplatize /bin/detemplatize 
       ```
-
+   
    b. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
       For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
       Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -10,7 +10,19 @@ To build a custom pega-web-ready image using your preferred OS and JDK, perform 
 
 1. Create a Dockerfile for your custom pega-web-ready image using your base image.
    
-   a. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
+   a. Use multi-stage Docker build at the beginning of your Dockerfile to copy the detemplatize executive file from the `pegasystems/detemplatize` Docker image to your base image.
+      The detemplatize executive file replaces template variables with actual values in the Pega Platform code.
+
+   For example:
+      ```Dockerfile
+      FROM pegasystems/detemplatize AS builder
+      # Base Image to be used to build pega-ready image 
+      FROM <BASE_IMAGE>
+      # Copy detemplatize to base image bin directory
+      COPY --from=builder /bin/detemplatize /bin/detemplatize 
+      ```
+
+   b. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
       For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
       Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.
 

--- a/docs/Building-Image-With-Own-OS-And-JDK.md
+++ b/docs/Building-Image-With-Own-OS-And-JDK.md
@@ -9,23 +9,10 @@ Pega provides a pega-web-ready Docker image using Tomcat 9 and JDK 11 as a base 
 To build a custom pega-web-ready image using your preferred OS and JDK, perform the following actions:
 
 1. Create a Dockerfile for your custom pega-web-ready image using your base image.
-     
-   a. Use multi-stage Docker build at the beginning of your Dockerfile to copy the detemplatize executive file from the `pegasystems/detemplatize` Docker image to your base image.
-      The detemplatize executive file replaces template variables with actual values in the Pega Platform code.
-
-   For example:
-      ```Dockerfile
-      FROM pegasystems/detemplatize AS builder
-      # Base Image to be used to build pega-ready image 
-      FROM <BASE_IMAGE>
-      # Copy detemplatize to base image bin directory
-      COPY --from=builder /bin/detemplatize /bin/detemplatize 
-      ```
    
-   b. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
+   a. Use the open-source pega-web-ready Dockerfile code to complete the Dockerfile.
       For more information, see pegasystems/docker-pega-web-ready/Dockerfile.
       Note: You can add any extra environment variables needed in the Dockerfile as per your use-case.
-
 
 2. Use the following command to build the custom pega-web-ready image using the base image as an argument.
      ```bash


### PR DESCRIPTION
Using detemplatize image as multi stage docker build, to avoid writing custom code to copy detemplatize library for building images with different OS and JDK.