### PR TITLE
BUG-879464: increase operations-per-run for stale action bot as default 30 is not sufficient

### DIFF
--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 200
           # timing
           days-before-stale: 60 # 60 days of inactivity
           days-before-close: 30 # 30 more days of inactivity


### PR DESCRIPTION
increase operations-per-run for stale action bot as default 30 exceeding the limit and operations are exiting with (No more operations left! Exiting...)