### PR TITLE
BUG-888436: Update upload-artifact version to v4

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -75,7 +75,7 @@ jobs:
       
     - name: Publish Scan Results as Artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: docker-scan-results
         path: ${{ steps.scan.outputs.sarif }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -8,6 +8,8 @@ ignore:
   - vulnerability: CVE-2016-6325
   - vulnerability: CVE-2020-8022
   - vulnerability: CVE-2022-42800
+  - vulnerability: CVE-2024-34156
+  - vulnerability: CVE-2024-34158
 
   # https://nvd.nist.gov/vuln/detail/CVE-2020-35527  https://ubuntu.com/security/CVE-2020-35527
   # In SQLite 3.31.1, there is an out of bounds access problem through ALTER TABLE for views that have a nested FROM clause.


### PR DESCRIPTION
Updated upload-artifact version to v4
The CVE-2024-34156 and CVE-2024-34158 vulnerabilities are being ignored because there are currently no available fixes for them

Created an internal work item(BUG-888445) to fix the above vulnerabilities.