### PR TITLE
Add contents of WEB_XML_SNIPPET to web.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ NODE_TYPE 					| Specify a node type or classification to specialize the process
 PEGA_DIAGNOSTIC_USER 		| Set a Pega diagnostic username to download log files. |
 PEGA_DIAGNOSTIC_PASSWORD 	| Set a secure Pega diagnostic username to download log files. |
 NODE_TIER                 | Specify the display name of the tier to which you logically associate this node. |
+WEB_XML_SNIPPET | Specify additional text to be inserted before the closing tag of web.xml. This can be used to add JMS Resource References. |
 
 ### Customize the Tomcat runtime
 
@@ -189,7 +190,6 @@ JAVA_OPTS 		| Specify any additional parameters that should be appended to the `
 INITIAL_HEAP 	| Specify the initial size (`Xms`) of the java heap. | `2048m`
 MAX_HEAP 		| Specify the maximum size (`Xmx`) of the java heap. | `4096m`
 HEAP_DUMP_PATH 	| Specify a location for a heap dump using `XX:HeapDumpPath` | `/heapdumps`
-
 
 ### Cassandra settings
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -317,6 +317,14 @@ else
 fi
 
 #
+# Adding snippet to web.xml
+#
+if [ -n "$WEB_XML_SNIPPET" ]; then
+  echo "Inserting WEB_XML_SNIPPET into web.xml";
+  awk -v var="$WEB_XML_SNIPPET" '/<\/web-app>/ {print var;} 1' ${PEGA_DEPLOYMENT_DIR}/WEB-INF/web.xml > /tmp/web.xml && mv /tmp/web.xml ${PEGA_DEPLOYMENT_DIR}/WEB-INF/web.xml
+fi
+
+#
 # Copying mounted catalina.properties file to conf
 #
 if [ -e "${catalina_properties}" ]; then

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -1639,7 +1639,7 @@ commandTests:
     exitCode: 0
     expectedOutput: ["Loading web.xml from /opt/pega/config/web.xml"]
 
-  # Dockerize prweb.xml check with WEB_XML_SNIPPET
+  # Dockerize web.xml check with WEB_XML_SNIPPET
   - name: "Dockerize PRWEB Check with WEB_XML_SNIPPET"
     envVars:
       - key: "JDBC_URL"

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -1639,6 +1639,32 @@ commandTests:
     exitCode: 0
     expectedOutput: ["Loading web.xml from /opt/pega/config/web.xml"]
 
+  # Dockerize prweb.xml check with WEB_XML_SNIPPET
+  - name: "Dockerize PRWEB Check with WEB_XML_SNIPPET"
+    envVars:
+      - key: "JDBC_URL"
+        value: "jdbc:postgresql://localhost:5432/pegadb"
+      - key: "JDBC_CLASS"
+        value: "org.postgresql.Driver"
+      - key: "DB_USERNAME"
+        value: "postgres_user"
+      - key: "DB_PASSWORD"
+        value: "postgres_pass"
+      - key: "IS_PEGA_25_OR_LATER"
+        value: "false"
+      - key: "WEB_XML_SNIPPET"
+        value: "<resource-env-ref-type>javax.jms.QueueConnectionFactory</resource-env-ref-type>"
+    command: "bash"
+    args:
+      - -c
+      - |
+        mv /tests/test-artifacts/web.xml /opt/pega/config/web.xml &&
+        mkdir -p /usr/local/tomcat/webapps/prweb/WEB-INF/ &&
+        bash -c './scripts/docker-entrypoint.sh' &&
+        grep -zoc "<resource-env-ref-type>javax.jms.QueueConnectionFactory</resource-env-ref-type>[[:space:]]*</web-app>" /usr/local/tomcat/webapps/prweb/WEB-INF/web.xml || echo "WEB_XML_SNIPPET is not dockerized properly"
+    exitCode: 0
+    excludedOutput: ["WEB_XML_SNIPPET is not dockerized properly"]
+
   # Verify test case for mounted krb5.conf file
   - name: "Mounted krb5.conf"
     envVars:

--- a/tests/test-artifacts/web.xml
+++ b/tests/test-artifacts/web.xml
@@ -1,1 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp_1">
+
 mounted web.xml
+
+</web-app>


### PR DESCRIPTION
This is a proposed solution for US-613462 and https://github.com/pegasystems/pega-helm-charts/issues/577 which allows a user of the pega Helm chart to define an env variable WEB_XML_SNIPPET which will be inserted into the web.xml just before the tag. This allows users to:
Add an additional servlet
Add a security constraint
Add JMS resources

Without the snippet feature, the user needs to either embed an entire 1600+ line web.xml into their values file, or put a replacement web.xml into the config/deploy folder (which either means using local charts instead of hosting in a repository, or having to repackage every chart release with the customization).

This feature also pairs with the existing functionality we have for specifying a CONTEXT_XML_SNIPPET.