### PR TITLE
Only return 302 for requests to index.jsp, 404s for other requests.

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -11,6 +11,17 @@ ignore:
   - vulnerability: CVE-2024-34156
   - vulnerability: CVE-2024-34158
 
+  # https://nvd.nist.gov/vuln/detail/CVE-2025-22874
+  # Calling Verify with a VerifyOptions.KeyUsages that contains ExtKeyUsageAny unintentionally disabledpolicy validation.
+  # This only affected certificate chains which contain policy graphs, which are rather uncommon.
+  # The CVE is originating from the go standard library included in detemplatize utility and does not leverage the
+  # particularly problematic go methods.
+  # Severity: High
+  # Date Detected: 2025-06-16
+  # Date of next action: 2025-07-16
+  - vulnerability: CVE-2025-22874
+    fix-state: "not-fixed"
+
   # https://nvd.nist.gov/vuln/detail/CVE-2020-35527  https://ubuntu.com/security/CVE-2020-35527
   # In SQLite 3.31.1, there is an out of bounds access problem through ALTER TABLE for views that have a nested FROM clause.
   # SQLite is not leverage by this image. A fix appears to be in progress.

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -20,7 +20,6 @@ ignore:
   # Date Detected: 2025-06-16
   # Date of next action: 2025-07-16
   - vulnerability: CVE-2025-22874
-    fix-state: "not-fixed"
 
   # https://nvd.nist.gov/vuln/detail/CVE-2020-35527  https://ubuntu.com/security/CVE-2020-35527
   # In SQLite 3.31.1, there is an out of bounds access problem through ALTER TABLE for views that have a nested FROM clause.

--- a/tomcat-webapps/ROOT/index.jsp
+++ b/tomcat-webapps/ROOT/index.jsp
@@ -1,5 +1,10 @@
 <%
-    response.setStatus(302);
-    response.sendRedirect("/{{ .Env.PEGA_APP_CONTEXT_PATH }}/");
+    String path = request.getServletPath();
+    if ("/index.jsp".equals(path)) {
+      response.setStatus(302);
+      response.sendRedirect("/prweb/");
+    } else {
+      response.setStatus(404);
+    }
     response.setHeader( "Connection", "close" );
 %>

--- a/tomcat-webapps/ROOT/index.jsp
+++ b/tomcat-webapps/ROOT/index.jsp
@@ -2,7 +2,7 @@
     String path = request.getServletPath();
     if ("/index.jsp".equals(path)) {
       response.setStatus(302);
-      response.sendRedirect("/prweb/");
+      response.sendRedirect("/{{ .Env.PEGA_APP_CONTEXT_PATH }}/");
     } else {
       response.setStatus(404);
     }


### PR DESCRIPTION
Only return 302 for requests to index.jsp, 404s for other requests.

Returning 302 for everything appears to interfere with external authentication because of browser-initiated requests for favicon.ico.