### PR TITLE
Use tomcat/lib directory for VersionChecker classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COPY --chown=pegauser:root --from=builder /prweb ${CATALINA_HOME}/webapps/prweb
 RUN chmod -R g+rw   ${CATALINA_HOME}/webapps/prweb
 
 # Make a jdbc driver available to tomcat applications
-COPY --chown=pegauser:root /path/to/jdbcdriver.jar ${CATALINA_HOME}/lib/
+COPY --chown=pegauser:root /path/to/jdbcdriver.jar /opt/pega/lib/
 
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prconfig.xml
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prlog4j2.xml

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COPY --chown=pegauser:root --from=builder /prweb ${CATALINA_HOME}/webapps/prweb
 RUN chmod -R g+rw   ${CATALINA_HOME}/webapps/prweb
 
 # Make a jdbc driver available to tomcat applications
-COPY --chown=pegauser:root /path/to/jdbcdriver.jar /opt/pega/lib/
+COPY --chown=pegauser:root /path/to/jdbcdriver.jar ${CATALINA_HOME}/lib/
 
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prconfig.xml
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prlog4j2.xml

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -402,7 +402,7 @@ rm "${CATALINA_HOME}"/conf/server.xml.tmpl
 # the bootstrap classpath for tomcat.
 #
 if [ -z "${IS_PEGA_25_OR_LATER}" ]; then
-  vc_classpath="/opt/pega/utility/*:/opt/pega/lib/*"
+  vc_classpath="/opt/pega/utility/*:${CATALINA_HOME}/lib/*"
   vc_javaopts="-Xms${INITIAL_HEAP} -Xmx${MAX_HEAP} ${JAVA_OPTS} ${CATALINA_OPTS}"
   vc_javaopts="${vc_javaopts} --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
   vc_javaopts="${vc_javaopts} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED"


### PR DESCRIPTION
Users who followed the documented steps for building a custom image may put their JDBC driver directly into ${CATALINA_HOME}/lib instead of into /opt/pega/lib. Since we only include the latter on the VersionChecker classpath, the check fails and users would have to manually set the IS_PEGA_25_OR_LATER environment variable.

At the point this tool is running, we have already copied /opt/pega/lib into ${CATALINA_HOME}/lib, so we can maintain backward compatibility by switching to adding ${CATALINA_HOME}/lib to the VersionChecker classpath instead. This results in adding some tomcat jars to the classpath, but won't cause any problems for the tool.