### PR TITLE
Update documentation for where to supply JDBC driver in custom images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COPY --chown=pegauser:root --from=builder /prweb ${CATALINA_HOME}/webapps/prweb
 RUN chmod -R g+rw   ${CATALINA_HOME}/webapps/prweb
 
 # Make a jdbc driver available to tomcat applications
-COPY --chown=pegauser:root /path/to/jdbcdriver.jar ${CATALINA_HOME}/lib/
+COPY --chown=pegauser:root /path/to/jdbcdriver.jar /opt/pega/lib/
 
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prconfig.xml
 RUN chmod g+rw ${CATALINA_HOME}/webapps/prweb/WEB-INF/classes/prlog4j2.xml


### PR DESCRIPTION
The `/opt/pega/lib` location is a better location for users to put their JDBC driver/other files when making custom images. This would allow mounting the volume in case of init containers performing downloads/collection of other jars and the contents are copied into the tomcat/lib directory prior to startup.

closes #271 