### PR TITLE
ENHANCEMENT-2083

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ ENV JAVA_OPTS="" \
     NODE_TYPE="" \
     NODE_TIER="" \
     NODE_SETTINGS="" \
+    PEGA_LOG_TRACE_ID_ENABLED="false" \
     PEGA_APP_CONTEXT_PATH=prweb \
     PEGA_DEPLOYMENT_DIR=${CATALINA_HOME}/webapps/prweb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ ENV JAVA_OPTS="" \
     NODE_TYPE="" \
     NODE_TIER="" \
     NODE_SETTINGS="" \
-    PEGA_LOG_TRACE_ID_ENABLED="false" \
+    PEGA_LOG_CORRELATION_ID_ENABLED="false" \
     PEGA_APP_CONTEXT_PATH=prweb \
     PEGA_DEPLOYMENT_DIR=${CATALINA_HOME}/webapps/prweb
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -274,15 +274,15 @@ fi
 #
 # Copying mounted prlog4j2 file to webapps/prweb/WEB-INF/classes
 #
-if [ -e "$prlog4j2" ]; then
-  echo "Loading prlog4j2 from ${prlog4j2}...";
-  cp "$prlog4j2" ${PEGA_DEPLOYMENT_DIR}/WEB-INF/classes/
-elif [ -e "${final_config_root}/prlog4j2.xml.tmpl" ]; then
-  echo "No prlog4j2 was specified in ${prlog4j2}. Generating from mounted template."
+if [ -e "${final_config_root}/prlog4j2.xml.tmpl" ]; then
+  echo "Loading prlog4j2 template from ${final_config_root}/prlog4j2.xml.tmpl...";
   if ! /bin/detemplatize -template "${final_config_root}/prlog4j2.xml.tmpl:${PEGA_DEPLOYMENT_DIR}/WEB-INF/classes/prlog4j2.xml"; then
     echo "ERROR: Failed to render prlog4j2.xml.tmpl template. Exiting."
     exit 1
   fi
+elif [ -e "$prlog4j2" ]; then
+  echo "Loading prlog4j2 from ${prlog4j2}";
+  cp "$prlog4j2" ${PEGA_DEPLOYMENT_DIR}/WEB-INF/classes/
 else
   echo "No prlog4j2 was specified in ${prlog4j2}.  Using defaults."
 fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -42,7 +42,7 @@ final_config_root=$config_root
 
 if [ "$IS_PEGA_CONFIG_COMPRESSED" == true ]; then
     final_config_root=$decompressed_root
-    file_list=("prlog4j2.xml" "prconfig.xml" "context.xml" "server.xml" "web.xml" "tomcat-users.xml" "catalina.properties" "prbootstrap.properties" "java.security.overwrite" "tomcat-web.xml" "server.xml.tmpl" "context.xml.tmpl" "java.security.overwrite.tmpl")
+    file_list=("prlog4j2.xml" "prlog4j2.xml.tmpl" "prconfig.xml" "context.xml" "server.xml" "web.xml" "tomcat-users.xml" "catalina.properties" "prbootstrap.properties" "java.security.overwrite" "tomcat-web.xml" "server.xml.tmpl" "context.xml.tmpl" "java.security.overwrite.tmpl")
     # decompressing the files if exists
     for filename in "${file_list[@]}"; do
       if [ -e "${config_root}/${filename}" ]; then
@@ -277,6 +277,12 @@ fi
 if [ -e "$prlog4j2" ]; then
   echo "Loading prlog4j2 from ${prlog4j2}...";
   cp "$prlog4j2" ${PEGA_DEPLOYMENT_DIR}/WEB-INF/classes/
+elif [ -e "${final_config_root}/prlog4j2.xml.tmpl" ]; then
+  echo "No prlog4j2 was specified in ${prlog4j2}. Generating from mounted template."
+  if ! /bin/detemplatize -template "${final_config_root}/prlog4j2.xml.tmpl:${PEGA_DEPLOYMENT_DIR}/WEB-INF/classes/prlog4j2.xml"; then
+    echo "ERROR: Failed to render prlog4j2.xml.tmpl template. Exiting."
+    exit 1
+  fi
 else
   echo "No prlog4j2 was specified in ${prlog4j2}.  Using defaults."
 fi
@@ -396,6 +402,7 @@ fi
 rm "${CATALINA_HOME}"/conf/context.xml.tmpl
 rm "${CATALINA_HOME}"/conf/tomcat-users.xml.tmpl
 rm "${CATALINA_HOME}"/conf/server.xml.tmpl
+
 
 #
 # Determine whether we are running against a 25.1 + environment as it is necessary to add bc-fips libraries

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -27,6 +27,8 @@ metadataTest:
      value: 60000
    - key: ENABLE_CUSTOM_ARTIFACTORY_SSL_VERIFICATION
      value: false
+   - key: PEGA_LOG_TRACE_ID_ENABLED
+     value: false
   exposedPorts: ["8080", "9001", "47100", "7003"]
   # Add 5701-5710 ports                      
   entrypoint: [/scripts/docker-entrypoint.sh]

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -1631,6 +1631,35 @@ commandTests:
     exitCode: 0
     expectedOutput: ["Loading prlog4j2 from /opt/pega/config/prlog4j2.xml"]
 
+    # Verify template precedence when both prlog4j2 files exist
+  - name: "Mounted prlog4j2.xml.tmpl with legacy xml"
+    envVars:
+    - key: "JDBC_URL"
+      value: "jdbc:postgresql://localhost:5432/pegadb"
+    - key: "JDBC_CLASS"
+      value: "org.postgresql.Driver"
+    - key: "DB_USERNAME"
+      value: "postgres"
+    - key: "DB_PASSWORD"
+      value: "postgres"
+    - key: "RULES_SCHEMA"
+      value: "rules"
+    - key: "DATA_SCHEMA"
+      value: "data"
+    - key: "IS_PEGA_25_OR_LATER"
+      value: "false"
+    command: "bash"
+    args:
+    - -c
+    - |
+        cp /tests/test-artifacts/prlog4j2.xml /opt/pega/config/prlog4j2.xml &&
+        cp /tests/test-artifacts/templates/prlog4j2.xml.tmpl /opt/pega/config/prlog4j2.xml.tmpl &&
+        bash -c './scripts/docker-entrypoint.sh' &&
+        diff /usr/local/tomcat/webapps/prweb/WEB-INF/classes/prlog4j2.xml /tests/test-artifacts/templates/expected_prlog4j2.xml || echo "prlog4j2.xml.tmpl is not properly taking precedence"
+    exitCode: 0
+    expectedOutput: ["Loading prlog4j2 template from /opt/pega/config/prlog4j2.xml.tmpl..."]
+    excludedOutput: ["prlog4j2.xml.tmpl is not properly taking precedence"]
+
     # Verify test case for mounted server.xml
   - name: "Mounted server.xml"
     envVars:

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -1653,8 +1653,10 @@ commandTests:
     - -c
     - |
         cp /tests/test-artifacts/prlog4j2.xml /opt/pega/config/prlog4j2.xml &&
+        # Template input under test.
         cp /tests/test-artifacts/templates/prlog4j2.xml.tmpl /opt/pega/config/prlog4j2.xml.tmpl &&
         bash -c './scripts/docker-entrypoint.sh' &&
+        # Golden output expected after rendering prlog4j2.xml.tmpl.
         diff /usr/local/tomcat/webapps/prweb/WEB-INF/classes/prlog4j2.xml /tests/test-artifacts/templates/expected_prlog4j2.xml || echo "prlog4j2.xml.tmpl is not properly taking precedence"
     exitCode: 0
     expectedOutput: ["Loading prlog4j2 template from /opt/pega/config/prlog4j2.xml.tmpl..."]

--- a/tests/pega-web-ready-testcases.yaml
+++ b/tests/pega-web-ready-testcases.yaml
@@ -27,7 +27,7 @@ metadataTest:
      value: 60000
    - key: ENABLE_CUSTOM_ARTIFACTORY_SSL_VERIFICATION
      value: false
-   - key: PEGA_LOG_TRACE_ID_ENABLED
+   - key: PEGA_LOG_CORRELATION_ID_ENABLED
      value: false
   exposedPorts: ["8080", "9001", "47100", "7003"]
   # Add 5701-5710 ports                      

--- a/tests/test-artifacts/templates/expected_prlog4j2.xml
+++ b/tests/test-artifacts/templates/expected_prlog4j2.xml
@@ -1,0 +1,2 @@
+Mounted prlog4j2.xml.tmpl
+

--- a/tests/test-artifacts/templates/expected_prlog4j2.xml
+++ b/tests/test-artifacts/templates/expected_prlog4j2.xml
@@ -1,2 +1,2 @@
+<!-- Intentionally identical content for the template precedence test. -->
 Mounted prlog4j2.xml.tmpl
-

--- a/tests/test-artifacts/templates/prlog4j2.xml.tmpl
+++ b/tests/test-artifacts/templates/prlog4j2.xml.tmpl
@@ -1,0 +1,2 @@
+Mounted prlog4j2.xml.tmpl
+

--- a/tests/test-artifacts/templates/prlog4j2.xml.tmpl
+++ b/tests/test-artifacts/templates/prlog4j2.xml.tmpl
@@ -1,2 +1,2 @@
+<!-- Intentionally identical content for the template precedence test. -->
 Mounted prlog4j2.xml.tmpl
-


### PR DESCRIPTION

- Dockerfile: added PEGA_LOG_CORRELATION_ID_ENABLED=false as a runtime environment variable, so "ext-correlation-id" and "int-correlation-id" logging is now explicitly configurable from the container.


- docker-entrypoint.sh: updated prlog4j2 handling to support prlog4j2.xml.tmpl in addition to the plain XML file. When present, the template is now rendered into WEB-INF/classes/prlog4j2.xml via detemplatize, and it takes precedence over the legacy prlog4j2.xml. The compressed-config decompression list was also expanded to include prlog4j2.xml.tmpl.