### PR TITLE
ENHANCEMENT-2018 Add dedicated Tomcat health probe connector on port 8081 with isolated thread pool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -320,8 +320,8 @@ CMD ["run"]
 
 # Expose required ports
 
-# HTTP is 8080, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
-EXPOSE 8080 9001 9090 5701-5710 47100 7003
+# HTTP is 8080, health probes are 8081, JMX is 9001, prometheus is 9090, Hazelcast is 5701-5710, Ignite is 47100, REST for Kafka is 7003
+EXPOSE 8080 8081 9001 9090 5701-5710 47100 7003
 
 # Used by Docker if this image is used outside of a Kubernetes context.
 # Kubernetes ignores this check and uses the liveness/readiness probes instead.

--- a/tests/test-artifacts/templates/expected_server.xml
+++ b/tests/test-artifacts/templates/expected_server.xml
@@ -73,10 +73,10 @@
                maxSavePostSize="65536"
                connectionTimeout="20000" />
 
-    <!-- facilitates liveness check via separate port -->
+    <!-- facilitates liveness, readiness, and startup checks via a separate port -->
     <Connector port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
                connectionTimeout="20000"
-	       maxThreads="1"/>
+               maxThreads="2"/>
 
     <!-- Define a SSL/TLS HTTPS Connector on port 8443 -->
 

--- a/tests/test-artifacts/templates/server.xml.tmpl
+++ b/tests/test-artifacts/templates/server.xml.tmpl
@@ -73,10 +73,10 @@
                maxSavePostSize="65536"
                connectionTimeout="20000" />
 
-    <!-- facilitates liveness check via separate port -->
+    <!-- facilitates liveness, readiness, and startup checks via a separate port -->
     <Connector port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
                connectionTimeout="20000"
-	       maxThreads="1"/>
+               maxThreads="2"/>
 
     <!-- Define a SSL/TLS HTTPS Connector on port 8443 -->
     {{ if and .Env.TOMCAT_KEYSTORE_DIR .Env.TOMCAT_KEYSTORE_PASSWORD }}

--- a/tomcat-conf/server.xml
+++ b/tomcat-conf/server.xml
@@ -68,6 +68,11 @@
     -->
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000" />
+
+    <!-- facilitates liveness, readiness, and startup checks via a separate port -->
+    <Connector port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+               connectionTimeout="20000"
+               maxThreads="2" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
**PR Title:**
Add dedicated Tomcat health probe connector on port 8081 with isolated thread pool

---

**PR Description**

## Summary

Adds a separate Tomcat HTTP connector on port **8081** dedicated to Kubernetes liveness, readiness, and startup probes, with a **2-thread pool** to prevent probe requests from contending with each other or with application traffic on the main port.

## Problem

When health probes share the default Tomcat connector (port 8080), they compete with application requests for threads. Under high load or during slow startups, the main connector's thread pool can become saturated, causing probe requests to queue. This leads to:

- **False-positive probe failures** — Kubernetes may restart pods that are actually healthy but simply have no free threads to serve the probe.
- **Liveness and readiness blocking each other** — with a single-threaded health connector (the previous template default of `maxThreads="1"`), a slow liveness check blocks the readiness check (or vice versa), potentially causing cascading restarts.

## Solution

Introduced a dedicated NIO2 connector on port 8081 with `maxThreads="2"`, ensuring:

1. **Isolation from application traffic** — probes are served on a separate port with their own thread pool, unaffected by load on port 8080.
2. **No mutual blocking between probes** — with 2 threads, liveness and readiness (or startup) probes can execute concurrently without waiting on each other.
3. **Minimal resource overhead** — only 2 threads are allocated, keeping the footprint negligible.

## Changes

| File | Description |
|------|-------------|
| `tomcat-conf/server.xml` | Added a new `Connector` on port 8081 using `Http11Nio2Protocol` with `maxThreads="2"` and `connectionTimeout="20000"` |
| `Dockerfile` | Added port `8081` to the `EXPOSE` directive alongside existing ports |
| `tests/test-artifacts/templates/server.xml.tmpl` | Updated the templated health connector: revised comment and changed `maxThreads` from `1` to `2` |
| `tests/test-artifacts/templates/expected_server.xml` | Updated expected test output to match the new connector configuration |

## Kubernetes probe configuration example

After this change, configure your pod probes to target port 8081:

```yaml
livenessProbe:
  httpGet:
    path: /
    port: 8081
  initialDelaySeconds: 60
  periodSeconds: 10

readinessProbe:
  httpGet:
    path: /
    port: 8081
  initialDelaySeconds: 30
  periodSeconds: 5

startupProbe:
  httpGet:
    path: /
    port: 8081
  failureThreshold: 30
  periodSeconds: 10
```

## Backward compatibility

- The main application connector on port **8080** is unchanged.
- Existing deployments that don't reference port 8081 are unaffected.
- Deployments already using the templated `server.xml.tmpl` with the old `maxThreads="1"` connector will pick up the updated thread count automatically.
